### PR TITLE
Upgrade RabbitMQ and the Clusterer plugin

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,12 +1,12 @@
-FROM rabbitmq:3.6.3-management
+FROM rabbitmq:3.6.6-management
 
-ENV RABBITMQ_CLUSTERER_VERSION 3.6.x-667f92b0
+ENV RABBITMQ_CLUSTERER_VERSION 1.0.3
 
 ENV RABBITMQ_BOOT_MODULE rabbit_clusterer
 
 ENV RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS "-pa /plugins/rabbitmq_clusterer.ez/rabbitmq_clusterer-${RABBITMQ_CLUSTERER_VERSION}/ebin"
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-    && wget -O /plugins/rabbitmq_clusterer.ez "https://www.rabbitmq.com/community-plugins/v3.6.x/rabbitmq_clusterer-${RABBITMQ_CLUSTERER_VERSION}.ez" \
+    && wget -O /plugins/rabbitmq_clusterer.ez "https://bintray.com/rabbitmq/community-plugins/download_file?file_path=rabbitmq_clusterer-${RABBITMQ_CLUSTERER_VERSION}.ez" \
     && rabbitmq-plugins enable rabbitmq_clusterer --offline \
     && apt-get purge -y --auto-remove ca-certificates wget


### PR DESCRIPTION
* Upgrades RabbitMQ to 3.6.6
* Installs rabbitmq_clusterer plugin version 1.0.3